### PR TITLE
Removed "import cv2"

### DIFF
--- a/src/generate_class_specific_samples.py
+++ b/src/generate_class_specific_samples.py
@@ -4,7 +4,6 @@ Created on Thu Oct 26 14:19:44 2017
 @author: Utku Ozbulak - github.com/utkuozbulak
 """
 import os
-import cv2
 import numpy as np
 
 from torch.optim import SGD


### PR DESCRIPTION
If I am not mistaken, this import can and should be removed in file `generate_class_specific_samples.py` as well.