### PR TITLE
Fix for a zero gradient.

### DIFF
--- a/src/gradcam.py
+++ b/src/gradcam.py
@@ -79,12 +79,15 @@ class GradCam():
         weights = np.mean(guided_gradients, axis=(1, 2))  # Take averages for each gradient
         # Create empty numpy array for cam
         cam = np.ones(target.shape[1:], dtype=np.float32)
-        # Multiply each weight with its conv output and then, sum
-        for i, w in enumerate(weights):
-            cam += w * target[i, :, :]
-        cam = np.maximum(cam, 0)
-        cam = (cam - np.min(cam)) / (np.max(cam) - np.min(cam))  # Normalize between 0-1
-        cam = np.uint8(cam * 255)  # Scale between 0-255 to visualize
+        # Occationally all weights can be equal or less than zero. This will cause a divide 
+        # by zero in normalization.
+        if not (np.max(weights) == np.min(weights) or np.max(weights) <= 0.0):
+            # Multiply each weight with its conv output and then, sum
+            for i, w in enumerate(weights):
+                cam += w * target[i, :, :]
+            cam = np.maximum(cam, 0)
+            cam = (cam - np.min(cam)) / (np.max(cam) - np.min(cam))  # Normalize between 0-1
+            cam = np.uint8(cam * 255)  # Scale between 0-255 to visualize
         cam = np.uint8(Image.fromarray(cam).resize((input_image.shape[2],
                        input_image.shape[3]), Image.ANTIALIAS))
         # ^ I am extremely unhappy with this line. Originally resizing was done in cv2 which


### PR DESCRIPTION
Thanks for the library, it has been super helpful! 

Found that very rarely the output weights can be all zero or all negative for a particular layer. If this is the case the following errors will occur:

first
```
~/pytorch-cnn-visualizations/src/gradcam.py:98: RuntimeWarning: invalid value encountered in true_divide
  cam = (cam - np.min(cam)) / (np.max(cam) - np.min(cam))  # Normalize between 0-1
```
Which will then cause the values of cam to subsequently be 0, causing the following error:
```
Traceback (most recent call last):
  File "/Users/dakotaboin/miniconda3/lib/python3.6/site-packages/PIL/Image.py", line 2515, in fromarray
    mode, rawmode = _fromarray_typemap[typekey]
KeyError: ((1, 1, 224), '|u1')

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "./run-network.py", line 48, in <module>
    save_class_activation_images(image, cam, "one")
  File "/Users/dakotaboin/Source/pytorch-cnn-visualizations/src/misc_functions.py", line 79, in save_class_activation_images
    save_image(activation_map, path_to_file)
  File "/Users/dakotaboin/Source/pytorch-cnn-visualizations/src/misc_functions.py", line 133, in save_image
    im = Image.fromarray(im.astype(np.uint8))
  File "/Users/dakotaboin/miniconda3/lib/python3.6/site-packages/PIL/Image.py", line 2517, in fromarray
    raise TypeError("Cannot handle this data type")
TypeError: Cannot handle this data type
```

Pull request simply adds an if statement which will detect these zero gradient cases so the divide by zero will not occur. Hope this is helpful!


P.S. The crash can also be fixed by changing line `src/misc_functions.py:129` to: `if im.shape[0] == 3 and np.max(im) <= 1:` however I feel like this treats on the symptom rather than the cause.
