### PR TITLE
added requires_grad = True for vanilla and guided backprop

### DIFF
--- a/src/guided_backprop.py
+++ b/src/guided_backprop.py
@@ -63,6 +63,8 @@ class GuidedBackprop():
 
     def generate_gradients(self, input_image, target_class):
         # Forward pass
+        # Calculate gradients up to the input image
+        input_image.requires_grad = True
         model_output = self.model(input_image)
         # Zero gradients
         self.model.zero_grad()

--- a/src/vanilla_backprop.py
+++ b/src/vanilla_backprop.py
@@ -30,6 +30,8 @@ class VanillaBackprop():
 
     def generate_gradients(self, input_image, target_class):
         # Forward
+        # Calculate gradients up to the input image
+        input_image.requires_grad = True
         model_output = self.model(input_image)
         # Zero grads
         self.model.zero_grad()


### PR DESCRIPTION
I had problems with your code using my own CNN and data, because the gradients where not computed up to the input image. Therefore, `grad_in[0]` in `hook_function` was `None`.
Manually setting `requires_grad = True` for the input data solved the issue for me.