### PR TITLE
Spline interpolation zoom

### DIFF
--- a/src/gradcam.py
+++ b/src/gradcam.py
@@ -4,6 +4,7 @@ Created on Thu Oct 26 11:06:51 2017
 @author: Utku Ozbulak - github.com/utkuozbulak
 """
 from PIL import Image
+from scipy.ndimage.interpolation import zoom
 import numpy as np
 import torch
 
@@ -85,14 +86,7 @@ class GradCam():
         cam = np.maximum(cam, 0)
         cam = (cam - np.min(cam)) / (np.max(cam) - np.min(cam))  # Normalize between 0-1
         cam = np.uint8(cam * 255)  # Scale between 0-255 to visualize
-        cam = np.uint8(Image.fromarray(cam).resize((input_image.shape[2],
-                       input_image.shape[3]), Image.ANTIALIAS))/255
-        # ^ I am extremely unhappy with this line. Originally resizing was done in cv2 which
-        # supports resizing numpy matrices with antialiasing, however,
-        # when I moved the repository to PIL, this option was out of the window.
-        # So, in order to use resizing with ANTIALIAS feature of PIL,
-        # I briefly convert matrix to PIL image and then back.
-        # If there is a more beautiful way, do not hesitate to send a PR.
+        cam = zoom(cam, np.array(input_image[0].shape[1:])/np.array(cam.shape)) # Spline interpolation zoom to input-image size
         return cam
 
 


### PR DESCRIPTION
One possibility could be to use spline interpolation zoom() function from scipy.ndimage.interpolation for resizing the Grad-CAM tiles.