### PR TITLE
Adding capability to choose device other than cpu and fixing/generalize

### DIFF
--- a/src/guided_backprop.py
+++ b/src/guided_backprop.py
@@ -16,8 +16,9 @@ class GuidedBackprop():
     """
        Produces gradients generated with guided back propagation from the given image
     """
-    def __init__(self, model):
-        self.model = model
+    def __init__(self, model, device_id = "cpu"):
+        self.device = device_id
+        self.model = model.to(self.device)
         self.gradients = None
         self.forward_relu_outputs = []
         # Put model in evaluation mode
@@ -63,17 +64,17 @@ class GuidedBackprop():
 
     def generate_gradients(self, input_image, target_class):
         # Forward pass
-        model_output = self.model(input_image)
+        model_output = self.model(input_image.to(self.device))
         # Zero gradients
         self.model.zero_grad()
         # Target for backprop
         one_hot_output = torch.FloatTensor(1, model_output.size()[-1]).zero_()
         one_hot_output[0][target_class] = 1
         # Backward pass
-        model_output.backward(gradient=one_hot_output)
+        model_output.backward(gradient=one_hot_output.to(self.device))
         # Convert Pytorch variable to numpy array
         # [0] to get rid of the first channel (1,3,224,224)
-        gradients_as_arr = self.gradients.data.numpy()[0]
+        gradients_as_arr = self.gradients.data.cpu().numpy()[0]
         return gradients_as_arr
 
 

--- a/src/vanilla_backprop.py
+++ b/src/vanilla_backprop.py
@@ -12,8 +12,9 @@ class VanillaBackprop():
     """
         Produces gradients generated with vanilla back propagation from the image
     """
-    def __init__(self, model):
-        self.model = model
+    def __init__(self, model, device_id ='cpu'):
+        self.device = device_id
+        self.model = model.to(self.device)
         self.gradients = None
         # Put model in evaluation mode
         self.model.eval()
@@ -30,17 +31,17 @@ class VanillaBackprop():
 
     def generate_gradients(self, input_image, target_class):
         # Forward
-        model_output = self.model(input_image)
+        model_output = self.model(input_image.to(self.device))
         # Zero grads
         self.model.zero_grad()
         # Target for backprop
         one_hot_output = torch.FloatTensor(1, model_output.size()[-1]).zero_()
         one_hot_output[0][target_class] = 1
         # Backward pass
-        model_output.backward(gradient=one_hot_output)
+        model_output.backward(gradient=one_hot_output.to(self.device))
         # Convert Pytorch variable to numpy array
         # [0] to get rid of the first channel (1,3,224,224)
-        gradients_as_arr = self.gradients.data.numpy()[0]
+        gradients_as_arr = self.gradients.data.cpu().numpy()[0]
         return gradients_as_arr
 
 


### PR DESCRIPTION
#### Reference Issues/PRs
> None

#### What does this implementation fix?
> These changes mainly focus on augmenting the code to make it more usable and generalize.

1. **Run on GPU**: Modern architectures are so deep and computation extensive, that running it only on CPU may always result in out of memory error.  In this implementation, I have changed grad-cam, guided-backprop, integrated-gradient, layer-activation-with-guided-backprop, score-cam, and vanilla-backprop to be able to initialize with desired device ids as per our will. And then the model forward function and backward gradient calculations can be done on GPU devices. If nothing is provided at the time of initialization, the code simply follows the existing.

2.  **Introduction of forward hook**:  When we make models in Pytorch it is not essential that model class and the forward function contain the same layers. For example, often designers don't keep Flatten and Concat functions out of the class, And only perform them in forward section. So in Cam extractors, forward_pass_on_convolutions function looping over the layer of the model until the desired layer is reached may not depict the correct functionality of the forward function of the model. Hence we just added forward hook of the desired conv layer and let the model complete its forward pass without intervention. This way we can get the conv layer output as well as the correct output of the entire model in way more general way without the dependency of the forward function.

#### Other comments
> No

 